### PR TITLE
Add JSDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,14 +157,14 @@ You can also configure how the library behaves by using the exported `configure`
 
 The following table shows the correspondence between the global `Config` properties and the per-instance `data` equivalents:
 
-| Global `Config` property | Per-instance `data` equivalent |
-| ------------------------ | ------------------------------ |
-| `content`                | `data-lettercrap`              |
-| `letters`                | `data-lettercrap-letters`      |
-| `words`                  | `data-lettercrap-words`        |
-| `font_family`            | `data-lettercrap-font-family`  |
-| `font_weight`            | `data-lettercrap-font-weight`  |
-| `update_interval`        | `data-lettercrap-interval`     |
+| Global `Config` property | Per-instance `data` equivalent | Accepted values                                                             |
+| ------------------------ | ------------------------------ | --------------------------------------------------------------------------- |
+| `content`                | `data-lettercrap`              | Non-blank string                                                            |
+| `letters`                | `data-lettercrap-letters`      | Non-blank string                                                            |
+| `words`                  | `data-lettercrap-words`        | Non-blank string array                                                      |
+| `font_family`            | `data-lettercrap-font-family`  | [font-family](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family) |
+| `font_weight`            | `data-lettercrap-font-weight`  | [font-weight](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight) |
+| `update_interval`        | `data-lettercrap-interval`     | Positive integer or zero                                                    |
 
 Please note that changes to default options will not propagate to instances that have already been rendered.
 To synchronize the rendered instances that rely on default settings, you can call the `refresh` function:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "predev": "npm run build",
     "dev": "http-server -o example/index.html -s -c-1 -p 8080",
     "build:css": "cleancss src/lettercrap.css --output dist/lettercrap.min.css",
-    "build:ts": "esbuild src/index.ts --bundle --minify --format=esm --tsconfig=tsconfig.json --outfile=dist/lettercrap.min.js",
+    "build:ts": "esbuild src/index.ts --bundle --minify --legal-comments=eof --format=esm --tsconfig=tsconfig.json --outfile=dist/lettercrap.min.js",
     "build:types": "tsc --emitDeclarationOnly",
     "build": "npm-run-all --parallel build:*",
     "prebuild": "npm run clean",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "predev": "npm run build",
     "dev": "http-server -o example/index.html -s -c-1 -p 8080",
     "build:css": "cleancss src/lettercrap.css --output dist/lettercrap.min.css",
-    "build:ts": "esbuild src/index.ts --bundle --minify --legal-comments=eof --format=esm --tsconfig=tsconfig.json --outfile=dist/lettercrap.min.js",
+    "build:ts": "esbuild src/index.ts --bundle --minify --format=esm --tsconfig=tsconfig.json --outfile=dist/lettercrap.min.js",
     "build:types": "tsc --emitDeclarationOnly",
     "build": "npm-run-all --parallel build:*",
     "prebuild": "npm run clean",

--- a/src/lettercrap.css
+++ b/src/lettercrap.css
@@ -3,6 +3,7 @@
  * @author Ozren Dabić
  * @author Davide Ciulla
  */
+
 [data-lettercrap] {
   white-space: pre;
   overflow: hidden;

--- a/src/lettercrap.css
+++ b/src/lettercrap.css
@@ -1,3 +1,8 @@
+/*!
+ * @licence MIT (https://lettercrap.github.io/lettercrap/LICENSE)
+ * @author Ozren Dabić
+ * @author Davide Ciulla
+ */
 [data-lettercrap] {
   white-space: pre;
   overflow: hidden;

--- a/src/lettercrap.ts
+++ b/src/lettercrap.ts
@@ -1,3 +1,8 @@
+/*!
+ * @licence MIT (https://lettercrap.github.io/lettercrap/LICENSE)
+ * @author Ozren Dabić
+ * @author Davide Ciulla
+ */
 import { z } from 'zod';
 
 import {

--- a/src/lettercrap.ts
+++ b/src/lettercrap.ts
@@ -9,6 +9,11 @@ import {
   WordsSchema,
 } from './schemas.ts';
 
+/**
+ * Default settings for Lettercrap.
+ *
+ * @since 1.0.0
+ */
 export type Config = z.infer<typeof ConfigSchema>;
 
 const config: Config = {
@@ -20,6 +25,13 @@ const config: Config = {
   update_interval: 150,
 };
 
+/**
+ * Configure the default settings for Lettercrap.
+ *
+ * @param userConfig - The user configuration to apply.
+ * @throws z.ZodError - If the provided configuration contains invalid values.
+ * @since 1.0.0
+ */
 export function configure(userConfig: Partial<Config>) {
   const cleanUserConfig = Object.fromEntries(Object.entries(userConfig).filter(([_key, val]) => val !== undefined));
   const preview = ConfigSchema.parse({ ...config, ...cleanUserConfig });
@@ -44,12 +56,33 @@ class InitializedInstance {
   }
 }
 
+/**
+ * Re-render all initialized Lettercrap elements.
+ * This is useful when synchronizing previously
+ * initialized elements with the current configuration.
+ *
+ * @returns A promise that resolves when all elements have been refreshed.
+ * @throws Error - If any of the elements can not be re-initialized.
+ * @since 1.0.0
+ * @see resetElements
+ * @see initElements
+ * @async
+ */
 export async function refresh() {
   const elements = Array.from(instances.keys());
   await resetElements(elements);
   await initElements(elements);
 }
 
+/**
+ * Reset the specified element.
+ *
+ * @param element - The element to reset.
+ * @returns A promise that resolves when the element has been reset.
+ * @throws Error - If the specified element is not initialized.
+ * @since 1.0.0
+ * @async
+ */
 export async function resetElement(element: HTMLDivElement) {
   return new Promise<void>((resolve, reject) => {
     const metadata = instances.get(element);
@@ -69,23 +102,70 @@ export async function resetElement(element: HTMLDivElement) {
   });
 }
 
+/**
+ * Reset all specified elements.
+ *
+ * @param elements - The elements to reset.
+ * @returns A promise that resolves when all elements have been reset.
+ * @throws Error - If any of the specified elements are not initialized.
+ * @since 1.0.0
+ * @see resetElement
+ * @async
+ */
 export async function resetElements(elements: HTMLDivElement[]) {
   return Promise.all(Array.from(elements).map(resetElement));
 }
 
+/**
+ * Reset all initialized elements.
+ *
+ * @returns A promise that resolves when all elements have been reset.
+ * @throws Error - If any of the elements can not be re-initialized.
+ * @since 1.0.0
+ * @see resetElements
+ * @async
+ */
 export async function reset() {
   return resetElements(Array.from(instances.keys()));
 }
 
+/**
+ * Initialize all Lettercrap elements.
+ *
+ * @returns A promise that resolves when all elements have been initialized.
+ * @throws Error - If any of the elements can not be initialized.
+ * @since 1.0.0
+ * @see initElements
+ * @async
+ */
 export async function init() {
   const elements = document.querySelectorAll<HTMLDivElement>('div[data-lettercrap], div[data-lettercrap-text]');
   return initElements(Array.from(elements));
 }
 
+/**
+ * Initialize the specified elements.
+ *
+ * @param elements - The elements to initialize.
+ * @returns A promise that resolves when all elements have been initialized.
+ * @throws Error - If any of the elements can not be initialized.
+ * @since 1.0.0
+ * @see initElement
+ * @async
+ */
 export async function initElements(elements: HTMLDivElement[]) {
   return Promise.all(Array.from(elements).map(initElement));
 }
 
+/**
+ * Initialize the specified element.
+ *
+ * @param element - The element to initialize.
+ * @returns A promise that resolves when the element has been initialized.
+ * @throws Error - If the specified element can not be initialized.
+ * @since 1.0.0
+ * @async
+ */
 export async function initElement(element: HTMLDivElement) {
   if (instances.has(element)) return;
 

--- a/src/lettercrap.ts
+++ b/src/lettercrap.ts
@@ -3,6 +3,7 @@
  * @author Ozren Dabić
  * @author Davide Ciulla
  */
+
 import { z } from 'zod';
 
 import {


### PR DESCRIPTION
Closes #16

I've added the JSDoc to all the exported functions and types. I have yet to add the ones for the `schema.ts`. Please check the documentation comments and let me know if they are missing any vital information. I based them on the [JSDoc reference](https://jsdoc.app/). Another thing I added was licensing information to both the source and minified files. Note that in the case of the `lettercrap.min.js`, I had to put it at the end of the file, as ESBuild was putting it in the middle by default, between the Zod and library code.